### PR TITLE
Split generate version into separate job to test passing the value

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Generate version based on date
         id: generate-version
-        run: echo "RELEASE_VERSION=$(date '+%Y-%m-%d_%H_%M')" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=$(date '+%Y-%m-%d_%H_%M')" >> $GITHUB_OUTPUT
       - name: Test output
         run: echo ${{ steps.generate-version.outputs.RELEASE_VERSION }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,18 +14,28 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  generate-version:
+    name: "Generate Version"
+    runs-on: ubuntu-latest
+    outputs:
+      RELEASE_VERSION: ${{ steps.generate-version.outputs.RELEASE_VERSION }}
+    steps:
+      - name: Generate version based on date
+        id: generate-version
+        run: echo "RELEASE_VERSION=$(date '+%Y-%m-%d_%H_%M')" >> $GITHUB_ENV
+      - name: Test output
+        run: echo ${{ steps.generate-version.outputs.RELEASE_VERSION }}
+
   deploy-staging:
     runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: write # Write is required to create/update releases AND to write tags
+    needs: generate-version
     environment: staging
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Generate version based on date
-        run: echo "RELEASE_VERSION=$(date '+%Y-%m-%d_%H_%M')" >> $GITHUB_ENV
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -39,12 +49,12 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE_VERSION }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.generate-version.outputs.RELEASE_VERSION }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging
           build-args: |
-            APP_VERSION=${{ env.RELEASE_VERSION }}
+            APP_VERSION=${{ needs.generate-version.outputs.RELEASE_VERSION }}
 
       - name: Create release
         uses: abusix/github-release-actions/create-prerelease@v0.1.0
         with:
-          release-version: ${{ env.RELEASE_VERSION }}
+          release-version: ${{ needs.generate-version.outputs.RELEASE_VERSION }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,6 @@ jobs:
       - name: Generate version based on date
         id: generate-version
         run: echo "RELEASE_VERSION=$(date '+%Y-%m-%d_%H_%M')" >> $GITHUB_OUTPUT
-      - name: Test output
-        run: echo ${{ steps.generate-version.outputs.RELEASE_VERSION }}
 
   deploy-staging:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update to include an example of passing an output between steps.

We got stuck with this briefly in the main `web` repo so I thought it's worth making clear here.