### PR TITLE
PLA-1131 Refer to prerelease action via commit hash

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -18,7 +18,7 @@ jobs:
       is-existing-release: ${{ steps.pre_release.outputs.is-existing-release }}
     steps:
       - name: Perform pre-release actions
-        uses: abusix/github-release-actions/perform-pre-release@PLA-1131-additional-outputs
+        uses: abusix/github-release-actions/perform-pre-release@68d37f93136bda66ad81820d2ca3adb9b5076ebe
         id: pre_release
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
           docker push ghcr.io/${{ github.repository }}:latest
 
       - name: Perform post-release actions
-        uses: abusix/github-release-actions/perform-post-release@PLA-1131-additional-outputs
+        uses: abusix/github-release-actions/perform-post-release@68d37f93136bda66ad81820d2ca3adb9b5076ebe
         id: post_release
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
             APP_VERSION=${{ needs.generate-version.outputs.RELEASE_VERSION }}
 
       - name: Create release
-        uses: abusix/github-release-actions/create-prerelease@PLA-1131-additional-outputs
+        uses: abusix/github-release-actions/create-prerelease@68d37f93136bda66ad81820d2ca3adb9b5076ebe
         with:
           release-version: ${{ needs.generate-version.outputs.RELEASE_VERSION }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PSA: When you refer to a github action via just the branch name you might not get the latest of that branch 🤷🏽 
At least that's what it seems like in my pipeline results...